### PR TITLE
Added ability to generate new boilerkey device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 config.json
 counter.json
 qrcode.svg
-
 __pycache__/
 .DS_Store

--- a/boilerkey.py
+++ b/boilerkey.py
@@ -92,6 +92,12 @@ def getCounter():
     with open(COUNTER_PATH, "r") as f:
         return json.load(f)["counter"]
 
+def getUsername():
+    with open(CONFIG_PATH, "r") as f:
+        parsed = json.load(f)
+        if "username" in parsed:
+            return parsed["username"]
+        return None
 
 def generatePassword():
     config = getConfig()
@@ -317,18 +323,19 @@ def autoSetup():
 
     activationData = getActivationData(link)
     activationData["pin"] = password.split(',')[0]
+    activationData["username"] = username
     createConfig(activationData)
     setCounter(0)
     print("Setup successful!")
 
     print("Here is your password: ", generatePassword())
 
-def check_setup():
+def checkSetup():
     if not os.path.isfile(CONFIG_PATH) or not os.path.isfile(COUNTER_PATH):
         autoSetup()
 
 def main():
-    check_setup()
+    checkSetup()
     print(generatePassword())
 
 

--- a/boilerkey.py
+++ b/boilerkey.py
@@ -2,6 +2,9 @@ import base64
 import json
 import os
 import sys
+import random
+import re
+from string import ascii_lowercase
 
 try:
     import requests
@@ -64,9 +67,9 @@ def validateLink(link):
         assert "m-1b9bef70.duosecurity.com" in link
         code = link.split("/")[-1]
         assert len(code) == 20
-        return True, code
+        return code
     except Exception:
-        return False, None
+        return None
 
 
 def createConfig(activationData):
@@ -107,6 +110,134 @@ def generatePassword():
 
     return password
 
+def addBoilerKey(username, password, name="local_boilerkey"):
+    """
+    Send requests to purdue boilerkey management to add new boilerkey device
+
+    Returns 20 digit code used for duomobile registration
+
+    :param username: :class:`str` instance purdue username
+    :param password: :class:`str` instance password correlating
+        with username OTP: (****,******) OR 2fa password (****,push*)
+    :param password: :class:`str` instance name to register new boilerkey as
+        (Duplicate will have random string appended)
+    :raises ValueError: for invalid credentials (username, password)
+    :raises ValueError: for invalid name
+    :rtype: str OR None
+    """
+
+    headers = {
+    "User-Agent":
+        "Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.101 Safari/537.36",
+    }
+
+    name_re = re.compile("^[a-zA-Z0-9_]{1,32}$")
+    if not name_re.match(name):
+        raise ValueError(f"Invalid name: '{name}'\nMust be:\n"
+                         "\t-Under 32 characters\n"
+                         "\t-Contain only a-Z 0-9 and '_'")
+    with requests.Session() as s:
+        s.headers.update(headers)
+        main_get = s.get("https://www.purdue.edu/apps/account/BoilerKeySelfServe")
+
+        # find lt secret
+        text = main_get.text
+        sub_to_find = '<input type="hidden" name="lt" value="'
+        start_ind = text.find(sub_to_find) + len(sub_to_find)
+        lt = text[start_ind:text.find('"', start_ind)]
+
+        # find post url
+        sub_to_find = '<form id="fm1" action="'
+        start_ind = text.find(sub_to_find) + len(sub_to_find)
+        login_form_url = "https://www.purdue.edu" + text[start_ind:text.find('"', start_ind)]
+
+        login_payload = {
+            'username': username,
+            'password': password,
+            'lt': lt,
+            'execution': 'e1s1',
+            '_eventId': 'submit',
+            'submit': 'Login'
+        }
+        login_form_post = s.post(login_form_url, data=login_payload)
+
+        # check for auth failure
+        if "https://www.purdue.edu/apps/account/flows/BoilerKey" not in login_form_post.url and "https://www.purdue.edu/apps/account/cas/login" in login_form_post.url:
+            raise ValueError("Invalid credentials")
+        else:
+            print("Authenticated successfully\nPlease allow ~1min for slow purdue sites")
+
+        new_post_data = {
+            "_eventId": "boilerKeyDuoMobileCreate",
+            "_flowExecutionKey": "e1s1",
+            "phoneName":None,
+        }
+        new_post = s.post("https://www.purdue.edu/apps/account/flows/BoilerKey?execution=e1s1", data=new_post_data)
+
+        # get flow string number (required for request to be processed)
+        text = new_post.url
+        start_ind = text.find("e1s") + 3
+        flow_str = "e1s" + text[start_ind:]
+
+        cont_post_data = {
+            "_eventId": "duoMobileCreateProcessDownloadAppAction",
+            "_flowExecutionKey": flow_str
+        }
+        cont_post = s.post("https://www.purdue.edu/apps/account/flows/BoilerKey?execution={}".format(flow_str), data=cont_post_data)
+
+        # get flow string number (required for request to be processed)
+        text = cont_post.url
+        start_ind = text.find("e1s") + 3
+        flow_str = "e1s" + text[start_ind:]
+
+        pin_post_data = {
+            "_eventId": "duoMobileCreateProcessSetPinAction",
+            "_flowExecutionKey": flow_str,
+            "existingPin": password.split(",")[0]
+        }
+        pin_post = s.post("https://www.purdue.edu/apps/account/flows/BoilerKey?execution={}".format(flow_str), data=pin_post_data)
+
+        # get flow string number (required for request to be processed)
+        text = pin_post.url
+        start_ind = text.find("e1s") + 3
+        flow_str = "e1s" + text[start_ind:]
+
+        name_post_data = {
+            "_eventId": "duoMobileCreateProcessNameDeviceAction",
+            "_flowExecutionKey": flow_str,
+            "phoneName": name
+        }
+
+        name_post = s.post("https://www.purdue.edu/apps/account/flows/BoilerKey?execution={}".format(flow_str), data=name_post_data)
+
+        for i in range(0,5):
+            if "Sorry, you already have a Duo Mobile BoilerKey with that name" not in name_post.text:
+                break
+
+            # get flow string number (required for request to be processed)
+            text = name_post.url
+            start_ind = text.find("e1s") + 3
+            flow_str = "e1s" + text[start_ind:]
+
+            new_name = name + "_" + ''.join(random.choice(ascii_lowercase) for i in range(4))
+            if not name_re.match(new_name):
+                raise ValueError(f"Invalid name: '{name}'\nMust be:\n"
+                                 "\t-Under 32 characters\n"
+                                 "\t-Contain only a-Z 0-9 and '_'")
+            name_post_data = {
+                "_eventId": "duoMobileCreateProcessNameDeviceAction",
+                "_flowExecutionKey": flow_str,
+                "phoneName": new_name
+            }
+
+            name_post = s.post("https://www.purdue.edu/apps/account/flows/BoilerKey?execution={}".format(flow_str), data=name_post_data)
+
+        text = name_post.text
+        sub_to_find = 'https://m-1b9bef70.duosecurity.com/activate/'
+        start_ind = text.find(sub_to_find)
+        link = text[start_ind:text.find('"', start_ind)]
+
+        return validateLink(link)
 
 def askForInfo():
     print(
@@ -118,12 +249,12 @@ def askForInfo():
    under the qr code right here and press Enter"""
     )
 
-    valid = False
-    while not valid:
+    activationCode = None
+    while not activationCode:
         link = input()
-        valid, activationCode = validateLink(link)
+        activationCode = validateLink(link)
 
-        if not valid:
+        if not activationCode:
             print("Invalid link. Please try again")
 
     print(
@@ -144,11 +275,58 @@ def askForInfo():
 
     print("Here is your password: ", generatePassword())
 
+def getInput():
+    """
+    Get username and password from user
+
+    :rtype: tuple (username, password)
+    """
+    username = input("Purdue username\n:")
+    while not username:
+      username = input("\nYou must enter a username\nPurdue username\n:")
+
+    pass_re = re.compile("\d{4},(\d{6}|push\d*)")
+    password = input("Purdue password\n(Password may be of type '****,push', or '****,******')\n:")
+    re_match = pass_re.match(password)
+    while not re_match:
+        password = input("\nInvalid password\nPurdue password\n(Password may be of type '****,push', or '****,******')\n:")
+        re_match = pass_re.match(password)
+
+    return username, password
+
+
+def autoSetup():
+    """
+    Setup with automated boilerkey device creation
+
+    :rtype: None
+    """
+    print("This setup will add a new boilerkey device to your account.\n"
+          "Please note: you will receive an email notifying you your boilerkey settings have been changed\n"
+          "If you choose to use '****,push' type password, you will need to allow login on duo mobile\n"
+          "You may revoke access at any time from the boilerkey managment page\n\n"
+          "Setup:")
+    username, password = getInput()
+    link = None
+    while not link:
+        try:
+            link = addBoilerKey(username, password)
+        except ValueError as ve:
+            print('\n', ve)
+            username, password = getInput()
+
+    activationData = getActivationData(link)
+    activationData["pin"] = password.split(',')[0]
+    createConfig(activationData)
+    setCounter(0)
+    print("Setup successful!")
+
+    print("Here is your password: ", generatePassword())
 
 def main():
     if not os.path.isfile(CONFIG_PATH) or not os.path.isfile(COUNTER_PATH):
         print("Configuration files not found! Running setup...")
-        askForInfo()
+        autoSetup()
     else:
         print(generatePassword())
 

--- a/boilerkey.py
+++ b/boilerkey.py
@@ -323,12 +323,13 @@ def autoSetup():
 
     print("Here is your password: ", generatePassword())
 
-def main():
+def check_setup():
     if not os.path.isfile(CONFIG_PATH) or not os.path.isfile(COUNTER_PATH):
-        print("Configuration files not found! Running setup...")
         autoSetup()
-    else:
-        print(generatePassword())
+
+def main():
+    check_setup()
+    print(generatePassword())
 
 
 if __name__ == "__main__":

--- a/corec_utils.py
+++ b/corec_utils.py
@@ -45,9 +45,27 @@ class CorecAppointment():
 
         :rtype: bool
         """
-        if self.spots and self.spots > 0:
+        if self.appointmentId and self.hasSpots():
             return True
         return False
+
+    def hasSpots(self):
+        """Helper to determine whether Appointment has spots available
+        returns True if spots available, else False
+
+        :rtype: bool
+        """
+        if self.spots:
+            return self.spots > 0
+        return False
+
+    def __str__(self):
+        """toString equivalen will return string representation of object
+
+        :rtype: str
+        """
+
+        return f"date={self.date}, timeStr={self.timeStr}, participantId={self.participantId}, spots={self.spots}, appointmentId={self.appointmentId}, timeSlotId={self.timeSlotId}, timeSlotInstanceId={self.timeSlotInstanceId}"
 
 class CorecSession(requests.Session):
     """A Requests session with included helpers for corec site automation

--- a/corec_utils.py
+++ b/corec_utils.py
@@ -1,0 +1,313 @@
+import requests
+import json
+import datetime
+from bs4 import BeautifulSoup
+
+class CorecAppointment():
+    """An object to hold corec appointment info
+    :attribute participantId: :class:`str` instance recwell participantId
+        hash string (can be NONE) this is used to cancel said
+        appointment
+    :attribute spots: :class:`int` instance recwell spots availble
+        number (can be NONE)
+    :attribute appointmentId: :class:`str` instance recwell appointmentId
+        hash string
+    :attribute timeSlotId: :class:`str` instance recwell timeSlotId
+        hash string
+    :attribute timeSlotInstanceId: :class:`str` instance recwell
+        timeSlotInstanceId hash string
+    :attribute timeStr: :class:`str` instance recwell time string
+        ex: '9:00 - 10:00 am'
+    :attribute date: :class:`datetime.date` instance appt date
+    """
+    def __init__(self, participantId, spots, appointmentId, timeSlotId, timeSlotInstanceId, timeStr, date):
+        self.participantId = participantId
+        self.spots = spots
+        self.appointmentId = appointmentId
+        self.timeSlotId = timeSlotId
+        self.timeSlotInstanceId = timeSlotInstanceId
+        self.timeStr = timeStr
+        self.date = date
+
+    def canCancel(self):
+        """Helper to determine whether Appointment can be canceled
+        returns True if user currently has appointment, else False
+
+        :rtype: bool
+        """
+        if self.participantId:
+            return True
+        return False
+
+    def canReserve(self):
+        """Helper to determine whether Appointment can be acquired
+        returns True if user can get appointment, else False
+
+        :rtype: bool
+        """
+        if self.spots and self.spots > 0:
+            return True
+        return False
+
+class CorecSession(requests.Session):
+    """A Requests session with included helpers for corec site automation
+    Provides cookie persistence, connection-pooling, and configuration.
+    Basic Usage:
+      >>> import requests
+      >>> s = requests.Session()
+      >>> s.get('https://httpbin.org/get')
+      <Response [200]>
+    Or as a context manager::
+      >>> with requests.Session() as s:
+      ...     s.get('https://httpbin.org/get')
+      <Response [200]>
+
+
+      :attribute bookingId: :class:`str` instance recwell bookingId hash string
+      :attribute selectedFacilityId: :class:`str` instance recwell
+          selectedFacilityId hash string
+    """
+
+    def __init__(self):
+        """Override Session constructor to set default attributes for the gym
+        Still call super constructor to initialize Session
+        """
+
+        # id for the corec gym (opposed to pool etc)
+        self.facilityId = "3b2e5aa2-1715-4852-bea4-34f472771330"
+        # id for bookings for corec gym (opposed to pool etc)
+        self.bookingId = "83456ef4-1d99-4e58-8e66-eb049941f7c1"
+
+        # flag to tell if session is authenticated
+        self.authed = False
+
+        # call default Session constructor
+        super().__init__()
+
+    def authWithRecwell(self, username, password):
+        """Helper function to authenticate session with recwell site
+
+        After execution, session will be authenticated with recwell and able to
+        send requests for making/canceling appointments
+
+        :param username: :class:`str` instance purdue username
+        :param password: :class:`str` instance one-time-password correlating
+            with username (****,******)
+        :rtype: Boolean: indicating whether login was successful
+        """
+
+        if self.authed:
+            return True
+
+        # get form data
+        formGet = self.get("https://recwell.purdue.edu/Account/GetLoginOptions?returnURL=%2F&isAdmin=false")
+
+        # find __RequestVerificationToken
+        text = formGet.text
+        subToFind = 'name="__RequestVerificationToken" type="hidden" value="'
+        startInd = text.find(subToFind, text.find("frmExternalLogin")) + len(subToFind)
+        RequestVerificationToken = text[startInd:text.find('"', startInd)]
+
+        # create data dict to send as request body
+        frmExternalLoginData = {
+            '__RequestVerificationToken': RequestVerificationToken,
+            'provider': 'Shibboleth'
+        }
+        formPost = self.post("https://recwell.purdue.edu/Account/ExternalLogin?ReturnUrl=%2Fbooking", data=frmExternalLoginData)
+
+        # now at main purdue login form
+
+        # find lt
+        text = formPost.text
+        subToFind = '<input type="hidden" name="lt" value="'
+        startInd = text.find(subToFind) + len(subToFind)
+        lt = text[startInd:text.find('"', startInd)]
+
+        # find post url
+        subToFind = '<form id="fm1" action="'
+        startInd = text.find(subToFind) + len(subToFind)
+        loginFormUrl = "https://www.purdue.edu" + text[startInd:text.find('"', startInd)]
+
+        # create data dict to send as request body
+        loginData = {
+            'username': username,
+            'password': password,
+            'lt': lt,
+            'execution': 'e1s1',
+            '_eventId': 'submit',
+            'submit': 'Login'
+        }
+        loginFormPost = self.post(loginFormUrl, data=loginData)
+
+        # check for auth failure
+        if "https://www.recwell.purdue.edu" not in loginFormPost.url and "https://www.purdue.edu/apps/account/cas/login" in loginFormPost.url:
+            # possibly invalid credentials
+            # raise ValueError("Invalid credentials")
+            return False
+
+        # now at continue site (only accessable with js off)
+
+        # find post url
+        text = loginFormPost.text
+        subToFind = '<form action="'
+        startInd = text.find(subToFind) + len(subToFind)
+        continuePressUrl = text[startInd:text.find('"', startInd)]
+        continuePressUrl = continuePressUrl.replace("&#x3a;", ":").replace("&#x2f;", "/")
+
+        # find RelayState
+        subToFind = 'name="RelayState" value="'
+        startInd = text.find(subToFind) + len(subToFind)
+        RelayState = text[startInd:text.find('"', startInd)]
+        RelayState = RelayState.replace("&#x3a;", ":").replace("&#x2f;", "/")
+
+        # find SAMLResponse
+        subToFind = 'name="SAMLResponse" value="'
+        startInd = text.find(subToFind) + len(subToFind)
+        SAMLResponse = text[startInd:text.find('"', startInd)]
+
+        # create data dict to send as request body
+        continuePressPayload = {
+            "RelayState": RelayState,
+            "SAMLResponse": SAMLResponse,
+            "submit": "Continue",
+        }
+        continuePressPayload = self.post(continuePressUrl, data=continuePressPayload)
+        self.authed = True
+        return True
+
+    def getAppointment(self, appt):
+        """Helper function to send booking request
+
+        Send booking request to corec
+
+        :param appt: class: 'CorecAppointment' instance
+
+        :rtype: bool indicating success of appointment acquisition
+        """
+
+        if not appt.canReserve():
+            return False
+
+        if not self.authed:
+            return False
+
+        bookingId = self.bookingId
+        selectedFacilityId = self.facilityId
+
+        reqData = {
+            "bookingId": bookingId,
+            "facilityId": selectedFacilityId,
+            "appointmentId": appt.appointmentId,
+            "timeSlotId": appt.timeSlotId,
+            "timeSlotInstanceId": appt.timeSlotInstanceId,
+            "year": appt.date.year,
+            "month": appt.date.month,
+            "day": appt.date.day
+        }
+
+        attempt = self.post("https://recwell.purdue.edu/booking/reserve", data=reqData)
+
+        # parse json out of response
+        try:
+            response = json.loads(attempt.text)
+        except JSONDecodeError:
+            # not authenticated
+            # raise Exception("Not logged in")
+            return False
+
+        return response["Success"]
+
+    def cancelAppointment(self, appt):
+        """Helper function to send booking cancelation request
+
+        Send booking cancelation request to corec
+
+        :param appt: class: 'CorecAppointment' instance
+
+        :rtype: bool indicating success of appointment acquisition
+        """
+
+        if not appt.canCancel():
+            return False
+
+        if not self.authed:
+            return False
+
+        bookingId = self.bookingId
+        selectedFacilityId = self.facilityId
+
+        delUrl = "https://recwell.purdue.edu/booking/delete/" + appt.participantId
+
+        attempt = self.post(delUrl)
+
+        # parse json out of response
+        try:
+            response = json.loads(attempt.text)
+        except JSONDecodeError:
+            # not authenticated
+            # raise Exception("Not logged in")
+            return False
+
+        return response
+
+    def getAppointmentsData(self, targetDay):
+        """Helper function to get appointment data
+
+        Send get request for target day. Returns dict of
+        {time_str: `CorecAppointment` instance}
+        where time_str is string of type "8 - 9:20 AM"
+
+        :param target_day: :class:`datetime.date` instance target day to scrape
+            appointments for
+        :rtype: dict
+        """
+
+        # sub_to_find = ''
+        # start_ind = text.find(sub_to_find) + len(sub_to_find)
+        # selectedFacilityId = text[start_ind:text.find('"', start_ind)]
+        # print(selectedFacilityId)
+
+        appDataUrl = "https://recwell.purdue.edu/booking/{}/slots/{}/{}/{}/{}".format(self.bookingId, self.facilityId, targetDay.year, targetDay.month, targetDay.day)
+
+        # check if this has odd status
+        appData = self.get(appDataUrl)
+        # print(app_data.text)
+        if appData.text.startswith("<!DOCTYPE html>"):
+            # raise Exception("Not logged in")
+            return None
+
+        soup = BeautifulSoup(appData.text, 'html.parser')
+        bookingDivs = soup.findAll("div", class_="booking-slot-item")
+        retData = {}
+        for timecard in bookingDivs:
+            participantId = timecard['data-participant-id']
+            if participantId == "00000000-0000-0000-0000-000000000000":
+                participantId = None
+
+            timeRange = timecard.p.strong.text.strip()
+
+            spots = timecard.span.text.strip().split(" ")[0]
+            try:
+                spots = int(spots)
+            except Exception:
+                if spots == "Booked":
+                    spots = None
+                spots = 0
+
+            if timecard.div.button.has_attr('onclick'):
+                resStr = timecard.div.button['onclick']
+                resLis = resStr[8:-1].split(', ')
+                appointmentId = resLis[0][1:-1]
+                timeSlotId = resLis[1][1:-1]
+                timeSlotInstanceId = resLis[2][1:-1]
+                if spots > 0:
+                    canRequest = True
+            else:
+                appointmentId = None
+                timeSlotId = None
+                timeSlotInstanceId = None
+                canRequest = False
+
+            retData[timeRange] = CorecAppointment(participantId, spots, appointmentId, timeSlotId, timeSlotInstanceId, timeRange, targetDay)
+
+        return retData

--- a/example.py
+++ b/example.py
@@ -7,7 +7,7 @@ def getAndCancel(username, password, timeStr, targetDate):
     # initialize CorecSession
     with corec_utils.CorecSession() as sesh:
         # log in to recwell
-        if not sesh.authWithRecwell(username, boilerkey.generatePassword()):
+        if not sesh.authWithRecwell(username, password):
             print("Error authenticating!!!")
 
         # This will store dictionary of availble CorecAppointment instances
@@ -32,3 +32,24 @@ def getAndCancel(username, password, timeStr, targetDate):
             # Canceling an appointment requires a CorecAppointent instance as an argument
             if sesh.cancelAppointment(appData[timeStr]):
                 print(f"Canceled appointment for {targetDate} at {targetDate}")
+
+def getAppointmentsData(username, password, targetDate):
+    # initialize CorecSession
+    with corec_utils.CorecSession() as sesh:
+        # log in to recwell
+        if not sesh.authWithRecwell(username, boilerkey.generatePassword()):
+            print("Error authenticating!!!")
+
+        # This will store dictionary of availble CorecAppointment instances
+        #   in appData
+        appData = sesh.getAppointmentsData(targetDate)
+        if not appData:
+            print("Error getting data!!! Did you authenticate?")
+        return appData
+
+boilerkey.checkSetup()
+
+with open("file.json", "w") as f:
+    data = getAppointmentsData(boilerkey.getUsername(), boilerkey.generatePassword(), datetime.date(2021, 3, 12))
+    strData = {k:str(data[k]) for k in data}
+    f.write(str(strData))

--- a/example.py
+++ b/example.py
@@ -1,0 +1,34 @@
+import corec_utils
+import boilerkey
+import time
+import datetime
+
+def getAndCancel(username, password, timeStr, targetDate):
+    # initialize CorecSession
+    with corec_utils.CorecSession() as sesh:
+        # log in to recwell
+        if not sesh.authWithRecwell(username, boilerkey.generatePassword()):
+            print("Error authenticating!!!")
+
+        # This will store dictionary of availble CorecAppointment instances
+        #   in appData
+        appData = sesh.getAppointmentsData(targetDate)
+        if not appData:
+            print("Error getting data!!! Did you authenticate?")
+
+        # Getting appointment requires a CorecAppointent instance as an argument
+        if timeStr in appData:
+            if not sesh.getAppointment(appData[timeStr]):
+                print("Error getting appointment!!! Did you authenticate?")
+
+        # This will store dictionary of availble CorecAppointment instances
+        #   in appData
+        # NOTE: you must re-get the appointment data after an update
+        appData = sesh.getAppointmentsData(targetDate)
+        if not appData:
+            print("Error getting data!!! Did you authenticate?")
+
+        if timeStr in appData:
+            # Canceling an appointment requires a CorecAppointent instance as an argument
+            if sesh.cancelAppointment(appData[timeStr]):
+                print(f"Canceled appointment for {targetDate} at {targetDate}")

--- a/getWhenAvailable.py
+++ b/getWhenAvailable.py
@@ -10,7 +10,7 @@ def getWhenAvailable(username, password, timeStr, targetDate, interval):
         # ensure we log in by allowing 3 attempts
         for i in range(0,3):
             # log in to recwell
-            if not sesh.authWithRecwell(username, boilerkey.generatePassword()):
+            if not sesh.authWithRecwell(username, password):
                 print("Error authenticating!!!")
                 time.sleep(10)
             else:
@@ -38,6 +38,12 @@ def getWhenAvailable(username, password, timeStr, targetDate, interval):
                 if appData[timeStr].canCancel():
                     print(f"Appointment already reserved at {datetime.datetime.now()}")
                     return False
+
+                # check if another appointment already reserved for said day
+                if appData[timeStr].hasSpots() and not appData[timeStr].canReserve():
+                    print(f"You already have an appointment on this day")
+                    return False
+
                 # only move forward if spots available
                 if appData[timeStr].canReserve():
                     for i in range(0,3):
@@ -47,15 +53,17 @@ def getWhenAvailable(username, password, timeStr, targetDate, interval):
                             time.sleep(10)
                         else:
                             return True
+                else:
+                    print(f"Tried to get appointment at {datetime.datetime.now()}")
             else:
                 print("Invalid data for attempting to get appointment!")
 
             time.sleep(interval)
 
 def main():
-    USERNAME = input("Enter Purdue Username: ")
+    USERNAME = boilerkey.getUsername()
     if not USERNAME:
-        USERNAME = "jgleeson"
+        USERNAME = input("Enter Purdue Username: ")
 
     targetMonth = input("Enter target month(0-12): ")
     targetDay = input("Enter target day(0-31): ")
@@ -73,7 +81,7 @@ def main():
     INTERVAL = 30
 
     # ensure credentials are set up
-    boilerkey.check_setup()
+    boilerkey.checkSetup()
 
     # get appointment
     if getWhenAvailable(USERNAME, boilerkey.generatePassword(), TARGET_TIME, TARGET_DAY, INTERVAL):

--- a/getWhenAvailable.py
+++ b/getWhenAvailable.py
@@ -61,6 +61,10 @@ def getWhenAvailable(username, password, timeStr, targetDate, interval):
             time.sleep(interval)
 
 def main():
+
+    # ensure credentials are set up
+    boilerkey.checkSetup()
+
     USERNAME = boilerkey.getUsername()
     if not USERNAME:
         USERNAME = input("Enter Purdue Username: ")
@@ -80,8 +84,6 @@ def main():
 
     INTERVAL = 30
 
-    # ensure credentials are set up
-    boilerkey.checkSetup()
 
     # get appointment
     if getWhenAvailable(USERNAME, boilerkey.generatePassword(), TARGET_TIME, TARGET_DAY, INTERVAL):

--- a/getWhenAvailable.py
+++ b/getWhenAvailable.py
@@ -1,0 +1,83 @@
+import corec_utils
+import boilerkey
+import time
+import datetime
+
+
+def getWhenAvailable(username, password, timeStr, targetDate, interval):
+    # initialize CorecSession
+    with corec_utils.CorecSession() as sesh:
+        # ensure we log in by allowing 3 attempts
+        for i in range(0,3):
+            # log in to recwell
+            if not sesh.authWithRecwell(username, boilerkey.generatePassword()):
+                print("Error authenticating!!!")
+                time.sleep(10)
+            else:
+                break
+        if not sesh.authed:
+            print("Could not authenticate! Check username/password")
+            return False
+
+        apptBooked = False
+        while not apptBooked:
+            appData = None
+
+            for i in range(0,3):
+                # This will store dictionary of availble CorecAppointment instances
+                #   in appData
+                appData = sesh.getAppointmentsData(targetDate)
+                if not appData:
+                    print("Error getting data! Did you enter an invalid date?")
+                    time.sleep(10)
+                else:
+                    break
+
+            if appData and timeStr in appData:
+                # check if appointment already reserved
+                if appData[timeStr].canCancel():
+                    print(f"Appointment already reserved at {datetime.datetime.now()}")
+                    return False
+                # only move forward if spots available
+                if appData[timeStr].canReserve():
+                    for i in range(0,3):
+                        # Getting appointment requires a CorecAppointent instance as an argument
+                        if not sesh.getAppointment(appData[timeStr]):
+                            print("Error getting appointment!")
+                            time.sleep(10)
+                        else:
+                            return True
+            else:
+                print("Invalid data for attempting to get appointment!")
+
+            time.sleep(interval)
+
+def main():
+    USERNAME = input("Enter Purdue Username: ")
+    if not USERNAME:
+        USERNAME = "jgleeson"
+
+    targetMonth = input("Enter target month(0-12): ")
+    targetDay = input("Enter target day(0-31): ")
+    targetYear = input("Enter target year: ")
+
+    targetMonth = int(targetMonth)
+    targetDay = int(targetDay)
+    targetYear = int(targetYear)
+
+    TARGET_DAY = datetime.date(targetYear, targetMonth, targetDay)
+
+
+    TARGET_TIME = input("Enter time interval EXACTLY as shown on corec website\nExample: '9:20 - 10:40 AM'\n:")
+
+    INTERVAL = 30
+
+    # ensure credentials are set up
+    boilerkey.check_setup()
+
+    # get appointment
+    if getWhenAvailable(USERNAME, boilerkey.generatePassword(), TARGET_TIME, TARGET_DAY, INTERVAL):
+        print(f"Successfully got appointment at {datetime.datetime.now()}")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests==2.25.1
+pyotp==2.6.0
+beautifulsoup4==4.9.3
+pyqrcode==1.2.1


### PR DESCRIPTION
# Main objective
Make tool (and eventually its derivatives hopefully) easier to setup
This change allows users to setup using their Purdue username and password, instead of having to manually add a new boiler key device and copy the link
Note that a one time password (\*\*\*\*,\*\*\*\*\*\*) can be used OR the password most students typically use (\*\*\*\*,push\*) can be used, however a duo mobile confirmation is required for the later option 

## Changes
### `validateLink`
Change return type from tuple `(bool, str)` to `str` for simplification
### `addBoilerKey`
Function automates adding a boilerkey device
Mimic normal request structure to get a new boiler key device and extract the duo mobile link
### `getInput`
Function gets username and password from user, ensuring password format is valid
### `autoSetup`
Function to set up config files by calling `addBoilerKey` to get duo mobile link